### PR TITLE
Update keywords for Gatsby Plugin Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "gatsby-plugin-channel",
   "version": "2.0.1",
+  "keywords":[
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "description": "Gatsby plugin to integrate Channel.io on your project.",
   "author": "Heeryong Kang <drakang4@gmail.com>",
   "repository": {


### PR DESCRIPTION
Hi there!

I noticed that your `package.json` was missing the keyword `gatsby-plugin`. This keyword will enable this plugin to be included in the Gatsby Plugin Library. You can check [Gatsby's documentation](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/) on how plugins are added.

cc: [Gatsby PR](https://github.com/gatsbyjs/gatsby/issues/14013) for more information about the plugin.